### PR TITLE
Fix premature end for nested streams (#6)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var StreamConcat = function(streams, options) {
 
     if (self.currentStream === null) {
       this.canAddStream = false;
-      self.push(null);
+      self.end();
     } else {
       self.currentStream.pipe(self, {end: false});
       var streamClosed = false;

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var file1Path = path.join(__dirname, 'file1.txt');
 var file2Path = path.join(__dirname, 'file2.txt');
 var outputPath = path.join(__dirname, 'output.txt');
+var outputPathIssue6 = path.join(__dirname, 'issue-6.dat');
 
 var StreamConcat = require('../index');
 
@@ -23,7 +24,42 @@ describe('Concatenation', function() {
     var output = fs.readFileSync(outputPath);
     assert.equal('The quick brown fox jumps over the lazy dog.', output.toString());
   });
+
+  it('#6)', function(done) {
+    var stream = require('stream');
+    var $ = function(buff) {
+      return new stream.Readable({
+        read: function() {
+          this.push(buff);
+          buff = null;
+        }
+      });
+    };
+
+    var header = Buffer.alloc(5);
+    var footer = Buffer.alloc(5);
+    var total = header.length+footer.length;
+    var all = [$(header)];
+    for (var i = 0; i < 5; i++) {
+      var one = Buffer.alloc(30*1024);
+      var two = Buffer.alloc(30*1024);
+      total += one.length + two.length;
+      all.push( new StreamConcat([ $(one), $(two) ]) );
+    }
+    all.push($(footer));
+    var master = new StreamConcat(all);
+    var file = outputPathIssue6;
+    var output = fs.createWriteStream(file);
+    master.pipe(output);
+    output.on('finish', function() {
+      assert.equal(fs.readFileSync(file).length, total);
+      done();
+    });
+
+  });
+
   after(function() {
     fs.unlinkSync(outputPath);
+    fs.unlinkSync(outputPathIssue6);
   });
 });


### PR DESCRIPTION
I've encountered an issue with the library that when trying to pipe nested streams to a filestream. The issue is hard to reproduce as it only seems to appear for certain setups - mainly with large streams - but the general setup is as follows:
```javascript
var StreamConcat = require('stream-concat');
var fs = require('fs');
var master = new StreamConcat([
  headerStream(),
  new StreamConcat([child, streams]),
  new StreamConcat([child, streams]),
  ...,
  footerStream()
]);
master.pipe(fs.createWriteStream('path/to/file'));
```
In certain cases I've experienced that the written file does not contain the footerStream. I found out that this was the case when certain child-streams contained chunks that were larger than 16kB, which is the default highWaterMark for fs.createWriteStream if I'm not mistaken.
I also noticed that
```javascript
var all = Buffer.alloc(0);
master.on('data', function(chunk) {
  all = Buffer.concat([all, chunk]);
});
```
works as expected.

Using some trial & error bughunting I found out that changing
```javascript
if (self.currentStream === null) {
  this.canAddStream = false;
  self.push(null);
}
```
to
```javascript
if (self.currentStream === null) {
  this.canAddStream = false;
  self.end();
}
```
fixed the issue. I don't know exactly why, but I guess it's related to the fact that pushing null is not the "proper" way of ending writable streams in this case.

I'm going to file a pull request for this. All tests still pass after applying this fix.